### PR TITLE
Changed Sign In to Sign Up as it is more accurate to what it does.

### DIFF
--- a/app/Views/templates/header.php
+++ b/app/Views/templates/header.php
@@ -129,7 +129,7 @@
             <div class="navbar-item">
               <div class="buttons">
               <?php if( session('is_logged') != TRUE): ?>
-                <a class="button is-primary" href="<?= base_url() ?>/users/register">Sign In</a>
+                <a class="button is-primary" href="<?= base_url() ?>/users/register">Sign Up</a>
                 <a class="button is-light" href="<?= base_url() ?>/users/login">Log In</a>
                 <?php else: ?>
                   <a class="button is-primary" href="<?= base_url() ?>/users/profile/<?= session('username') ?>">Profile</a>


### PR DESCRIPTION
'Sign In' implies that the user is already registered and can log in. Having 'Sing In' and 'Log In' is confusing. Changing 'Sing In' to 'Sing Up' reflects that it's actually to register a new account. Very small change.