### PR TITLE
Fix for user library error conflicting with the wishlist.

### DIFF
--- a/app/Controllers/Wishlists.php
+++ b/app/Controllers/Wishlists.php
@@ -6,11 +6,8 @@ use CodeIgniter\Controller;
 class Wishlists extends Controller{
   public function userwishlist($user_id){
     $wishlistmodel = new WishlistModel();
-    if(is_array($wishlistmodel->getUserWishlist($user_id))){
-      $data['wishlist'] = $wishlistmodel->getUserWishlist($user_id);
-    } else {
-      $data['error'] = "You don't have games on your Wishlist. Add some games!";
-    }
+    $data['wishlist'] = (array) $wishlistmodel->getUserWishlist($user_id);
+    
     return view('wishlists/userwishlist', $data);
   }
   public function isinwishlist($id){

--- a/app/Views/wishlists/userwishlist.php
+++ b/app/Views/wishlists/userwishlist.php
@@ -1,9 +1,9 @@
-<?php if(isset($error)): ?>
-  <p><?= $error ?></p>
+<?php if(count($wishlist) === 0): ?>
+  <p>You don't have games on your wishlist. Add some games!</p>
 <?php else: ?>
-  <?php foreach($wishlist as $wishlist): ?>
+  <?php foreach($wishlist as $wishlistGame): ?>
     <figure class="image is-96x96 is-fullwidth is-inline-block mt-1 mr-1">
-      <a href="<?= base_url() ?>/game/<?= $wishlist['game_slug'] ?>" title="<?= $wishlist['game_name'] ?>"><img src="<?= base_url() ?>/images/<?= $wishlist['game_image'] ?>-thumb.jpeg"></a>
+      <a href="<?= base_url() ?>/game/<?= $wishlistGame['game_slug'] ?>" title="<?= $wishlistGame['game_name'] ?>"><img src="<?= base_url() ?>/images/<?= $wishlistGame['game_image'] ?>-thumb.jpeg"></a>
     </figure>
   <?php endforeach; ?>
 <?php endif; ?>


### PR DESCRIPTION
Wishlist is only rendered when there are no errors. Because I have no games in my library an error is being raised which conflicts with the wishlist. As a result the wishlist also believes there are no games.

https://github.com/jolupa/stdbgames/blob/e7a39c2fd7996fea169327cfbe7a3b1625d9452f/app/Controllers/Libraries.php#L13

https://github.com/jolupa/stdbgames/blob/604a663abfef0b87ff461804e6646c5559df8b88/app/Views/wishlists/userwishlist.php#L1-L9

I've opened a PR to resolve the issue, though it bypasses the errors altogether. Also I've renamed the wishlist variable within the foreach loop to avoid confusion and unwanted side effects. Also note this hasn't been tested as I don't have your project set up.